### PR TITLE
fix(android): add waiting for ready callback context results

### DIFF
--- a/packages/cordova/src/android/AdMob.java
+++ b/packages/cordova/src/android/AdMob.java
@@ -46,8 +46,8 @@ public class AdMob extends CordovaPlugin {
         Action action = new Action(args);
         if (Actions.READY.equals(actionKey)) {
             readyCallbackContext = callbackContext;
-            waitingForReadyCallbackContextResults.forEach((item) -> {
-              readyCallbackContext(item);
+            waitingForReadyCallbackContextResults.forEach((result) -> {
+              readyCallbackContext.sendPluginResult(result);
             });
             waitingForReadyCallbackContextResults = null;
             JSONObject data = new JSONObject();

--- a/packages/cordova/src/android/AdMob.java
+++ b/packages/cordova/src/android/AdMob.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.util.Log;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
@@ -29,6 +31,8 @@ public class AdMob extends CordovaPlugin {
 
     private static final String TEST_APPLICATION_ID = "ca-app-pub-3940256099942544~3347511713";
 
+    private ArrayList<PluginResult> waitingForReadyCallbackContextResults = new ArrayList<PluginResult>();
+
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
@@ -42,7 +46,10 @@ public class AdMob extends CordovaPlugin {
         Action action = new Action(args);
         if (Actions.READY.equals(actionKey)) {
             readyCallbackContext = callbackContext;
-
+            waitingForReadyCallbackContextResults.forEach((item) -> {
+              readyCallbackContext(item);
+            });
+            waitingForReadyCallbackContextResults = null;
             JSONObject data = new JSONObject();
             try {
                 data.put("platform", "android");
@@ -106,7 +113,11 @@ public class AdMob extends CordovaPlugin {
 
         PluginResult result = new PluginResult(PluginResult.Status.OK, event);
         result.setKeepCallback(true);
-        readyCallbackContext.sendPluginResult(result);
+        if (readyCallbackContext == null) {
+          waitingForReadyCallbackContextResults.add(result);
+        } else {
+          readyCallbackContext.sendPluginResult(result);
+        }
     }
 
     private String getApplicationID() {


### PR DESCRIPTION
devices: SM-S327VL (android 6.0.1),  Redmi Note 5 Pro (android 8.1.0)
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.apache.cordova.CallbackContext.sendPluginResult(org.apache.cordova.PluginResult)' on a null object reference
       at admob.plugin.AdMob.emit(AdMob.java:109)
       at admob.plugin.AdMob.emit(AdMob.java:95)
       at admob.plugin.ads.AdListener.onAdLoaded(AdListener.java:14)
       at com.google.android.gms.internal.ads.zzvx.onAdLoaded(Unknown Source:10)
       at com.google.android.gms.internal.ads.zzxb.dispatchTransaction(Unknown Source:11)
       at com.google.android.gms.internal.ads.zzex.onTransact(Unknown Source:12)
       at android.os.Binder.transact(Binder.java:387)
       at og.b(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):14)
       at com.google.android.gms.ads.internal.client.ac.c(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):10)
       at com.google.android.gms.ads.internal.a.c(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):321)
       at com.google.android.gms.ads.internal.a.q(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):316)
       at com.google.android.gms.ads.internal.h.q(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):18)
       at com.google.android.gms.ads.internal.an.q(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):207)
       at com.google.android.gms.ads.internal.a.b(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):177)
       at com.google.android.gms.ads.internal.c.b(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):44)
       at com.google.android.gms.ads.internal.renderer.a.a(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):25)
       at com.google.android.gms.ads.internal.renderer.a.a(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):10)
       at com.google.android.gms.ads.internal.webview.j.p(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):110)
       at com.google.android.gms.ads.internal.webview.j.i(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):105)
       at com.google.android.gms.ads.internal.gmsg.r.a(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):6)
       at com.google.android.gms.ads.internal.webview.j.a(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):312)
       at com.google.android.gms.ads.internal.webview.ac.a(Unknown Source:4)
       at com.google.android.gms.ads.internal.webview.ad.run(Unknown Source:2)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at ze.a(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):5)
       at com.google.android.gms.ads.internal.util.e.a(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):11)
       at ze.dispatchMessage(:com.google.android.gms.dynamite_adsdynamite@15090046@15.0.90 (040306-231259764):4)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:7422)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
```