### PR TITLE
Fixes NoClassDefFoundError and NPE in Admob cordova plugin

### DIFF
--- a/packages/cordova/src/android/AdMob.java
+++ b/packages/cordova/src/android/AdMob.java
@@ -46,10 +46,10 @@ public class AdMob extends CordovaPlugin {
         Action action = new Action(args);
         if (Actions.READY.equals(actionKey)) {
             readyCallbackContext = callbackContext;
-            waitingForReadyCallbackContextResults.forEach((result) -> {
+            for (PluginResult result : waitingForReadyCallbackContextResults) {
               readyCallbackContext.sendPluginResult(result);
-            });
-            waitingForReadyCallbackContextResults = null;
+            }
+            waitingForReadyCallbackContextResults.clear();
             JSONObject data = new JSONObject();
             try {
                 data.put("platform", "android");


### PR DESCRIPTION
Apart from one single usage, the plugin currently does not seem to use
any Java 8 language APIs. The usage in question is in `Admob.java`:

```java
    waitingForReadyCallbackContextResults.forEach()
```

It compiles successfully with JavaVersion.VERSION_1_8 enabled, however,
it throws a runtime exception on Android SDK < 24 (< v7.0) devices.

```java
    java.lang.NoClassDefFoundError: admob.plugin.-$$Lambda$AdMob$GO15ms8Jdvu2s5w9ooldE6Mb0qs
```
It does not seem that the method is supported, at least in the Android documentation at
https://developer.android.com/studio/write/java8-support.html. This commit replaces the
`forEach()` call with a for-loop iteration.

The second part of the commit replaces nullification of the array with a clear() method call.

```java
    waitingForReadyCallbackContextResults = null;
```

It's not quite clear why this was set to null in the first place (Ref #81), however, it causes a NPE
in a case where the Cordova `ready` event gets triggered twice. The event could be triggered
several times for the case where the app contains `location.href = '...'` code which causes the  WebView to load another html file and re-trigger the `ready` event.