### PR TITLE
sendSubviewToBack was deprecated long ago

### DIFF
--- a/packages/cordova/src/ios/AMSBanner.swift
+++ b/packages/cordova/src/ios/AMSBanner.swift
@@ -52,7 +52,7 @@ class AMSBanner: AMSAdBase, GADBannerViewDelegate {
             background.translatesAutoresizingMaskIntoConstraints = false
             background.backgroundColor = .black
             view.addSubview(background)
-            view.sendSubviewToBack(background)
+            view.sendSubview(toBack: background)
             NSLayoutConstraint.activate([
                 background.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 background.trailingAnchor.constraint(equalTo: view.trailingAnchor),


### PR DESCRIPTION
Build was crashing, renamed `sendSubviewToBack` to `view.sendSubview(toBack: background)` and it works! 

Can you release this patch soon?