### PR TITLE
chore(android): upgrade firebase ads to v18.2.0

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ Via [Cordova CLI](https://www.npmjs.com/package/cordova):
 cordova plugin add cordova-admob-plus --variable APP_ID_ANDROID=ca-app-pub-xxx~xxx --variable APP_ID_IOS=ca-app-pub-xxx~xxx
 ```
 
-For Android developer, `com.google.android.gms:play-services-ads:$PLAY_SERVICES_VERSION` is available for configuration, the default is `--PLAY_SERVICES_VERSION=17.2.0`.
+For Android developer, `com.google.android.gms:play-services-ads:$PLAY_SERVICES_VERSION` is available for configuration, the default is `--PLAY_SERVICES_VERSION=18.2.0`.
 
 For iOS developer, add `<preference name="UseSwiftLanguageVersion" value="5" />` to `config.xml` for using Swift 5.
 

--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -38,7 +38,7 @@ repositories {
 
 
 dependencies {
-    api 'com.google.firebase:firebase-ads:17.2.0'
+    api 'com.google.firebase:firebase-ads:18.2.0'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     testImplementation 'junit:junit:4.12'

--- a/packages/cordova/plugin.xml
+++ b/packages/cordova/plugin.xml
@@ -14,7 +14,7 @@
 
     <platform name="android">
         <preference name="APP_ID_ANDROID" default="test" />
-        <preference name="PLAY_SERVICES_VERSION" default="17.2.0" />
+        <preference name="PLAY_SERVICES_VERSION" default="18.2.0" />
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <meta-data

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'com.google.firebase:firebase-ads:17.2.1'
+    implementation 'com.google.firebase:firebase-ads:18.2.0'
 }


### PR DESCRIPTION
Fix #124 

This enables user metric tracking when enabled in AdMob settings.