### PR TITLE
fixed android issue "java.lang.NullPointerException ... java.util.ArrayList.add(java.lang.Object)' on a null ...

### DIFF
--- a/packages/cordova/src/android/AdMob.java
+++ b/packages/cordova/src/android/AdMob.java
@@ -119,7 +119,9 @@ public class AdMob extends CordovaPlugin {
         PluginResult result = new PluginResult(PluginResult.Status.OK, event);
         result.setKeepCallback(true);
         if (readyCallbackContext == null) {
-          waitingForReadyCallbackContextResults.add(result);
+            if (waitingForReadyCallbackContextResults instanceof ArrayList) {
+                waitingForReadyCallbackContextResults.add(result);
+            }
         } else {
           readyCallbackContext.sendPluginResult(result);
         }


### PR DESCRIPTION
I was getting multiple occurrences of the following error in the GooglePlay pre-launch tests.
Unfortunately, I'm not familiar with the project: so I just patched the line that caused the exception, the reason that causes the issue may be somewhere else. 
I noted that whatever causes the issue, it usually occurs only on the first open of the app.

FATAL EXCEPTION: main [...] java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.util.ArrayList.add(java.lang.Object)' on a null object reference"