### PR TITLE
Add RewardVideoLoadFail Event on iOS

### DIFF
--- a/packages/cordova/src/ios/AMSRewardVideo.swift
+++ b/packages/cordova/src/ios/AMSRewardVideo.swift
@@ -28,6 +28,10 @@ class AMSRewardVideo: AMSAdBase, GADRewardBasedVideoAdDelegate {
     func rewardBasedVideoAd(_ rewardBasedVideoAd: GADRewardBasedVideoAd, didRewardUserWith reward: GADAdReward) {
         plugin.emit(eventType: AMSEvents.rewardVideoReward)
     }
+    
+    func rewardBasedVideoAd(_ rewardBasedVideoAd: GADRewardBasedVideoAd, didFailToLoadWithError error: Error) {
+        plugin.emit(eventType: AMSEvents.rewardVideoLoadFail)
+    }
 
     func rewardBasedVideoAdDidReceive(_ rewardBasedVideoAd: GADRewardBasedVideoAd) {
         plugin.emit(eventType: AMSEvents.rewardVideoLoad)


### PR DESCRIPTION
It appeared to me that the Promise of Reward Video's `load` Function was never resolved. I searched and it appeared that the RewardVideoLoadFail was never fired in iOS, so i added it and it works now.