### PR TITLE
Fix for error 65 while compiling for iOS

### DIFF
--- a/packages/cordova/src/ios/AMSBanner.swift
+++ b/packages/cordova/src/ios/AMSBanner.swift
@@ -59,7 +59,7 @@ class AMSBanner: AMSAdBase, GADBannerViewDelegate {
             background.translatesAutoresizingMaskIntoConstraints = false
             background.backgroundColor = .black
             view.addSubview(background)
-            view.sendSubviewToBack(background)
+            view.sendSubview(toBack: background)            
             NSLayoutConstraint.activate([
                 background.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 background.trailingAnchor.constraint(equalTo: view.trailingAnchor),


### PR DESCRIPTION
Changed from view.sendSubviewToBack(background) to view.sendSubview(toBack: background)