### PR TITLE
Plugin Consent - Android source copy

### DIFF
--- a/packages/cordova-consent/plugin.xml
+++ b/packages/cordova-consent/plugin.xml
@@ -13,8 +13,9 @@
                 <param name="android-package" value="cordova.plugin.consent.Consent"/>
             </feature>
 
-            <source-file src="src/android/Consent.java" target-dir="src/cordova/plugin/consent" />
         </config-file>
+        
+        <source-file src="src/android/Consent.java" target-dir="src/cordova/plugin/consent" />
 
         <preference name="CONSENT_SDK_VERSION" default="+" />
 


### PR DESCRIPTION
Fixed (to be tested) consent's plugin.xml to copy android source at install.

I could not test this commit fully, since the consent plugin is a sub-package of the original and this fork is not listed in npm.
Trying to install from local repo did not work either, so i ask the plugin maintainers to try this out for me. 
I believe the code is correct but of course it needs to be tested before merging.

Thank you.
