### PR TITLE
Fix events not emitted when a rewarded video is loaded (or failed loading)

### DIFF
--- a/packages/cordova/src/ios/AMSRewardVideo.swift
+++ b/packages/cordova/src/ios/AMSRewardVideo.swift
@@ -3,7 +3,6 @@ class AMSRewardVideo: AMSAdBase, GADRewardedAdDelegate {
 
     override init(id: Int, adUnitID: String) {
         super.init(id: id, adUnitID: adUnitID)
-        rewardBasedVideo = GADRewardedAd(adUnitID: adUnitID)
     }
 
     deinit {
@@ -15,8 +14,16 @@ class AMSRewardVideo: AMSAdBase, GADRewardedAdDelegate {
     }
 
     func load(request: GADRequest) {
-        if rewardBasedVideo?.isReady == false {
-            rewardBasedVideo?.load(request)
+        let rewardBasedVideo = GADRewardedAd(adUnitID: adUnitID)
+        self.rewardBasedVideo = rewardBasedVideo
+
+        rewardBasedVideo.load(request) { error in
+            if let error = error {
+                NSLog("Error while loading the reward based video: %@", error)
+                self.plugin.emit(eventType: AMSEvents.rewardVideoLoadFail)
+            } else {
+                self.plugin.emit(eventType: AMSEvents.rewardVideoLoad)
+            }
         }
     }
 


### PR DESCRIPTION
Thanks for this very nice plugin! :) 

It seems that rewarded video "load" or loading failure events were never properly fired - so that you could not know if a reward video is ready to be displayed. 

Note that there is a `func rewardedAd(_ rewardedAd: GADRewardedAd, didFailToPresentWithError error: Error)` but it's only when the video fails to play on screen, not when in fails to load. 