### PR TITLE
Page Not Found in installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AdMob Plus is the successor of [cordova-plugin-admob-free](https://github.com/ra
 
 ## Installation
 
-[Getting started on admob-plus.github.io](https://admob-plus.github.io/docs/installation.html)
+[Getting started on admob-plus.github.io](https://admob-plus.github.io/docs/)
 
 ## Contributing
 


### PR DESCRIPTION
`https://admob-plus.github.io/docs/installation.html` points to a "not found" page.