### PR TITLE
Update docs for banner to remove reference to load method

### DIFF
--- a/website/docs/cordova/ads/banner.md
+++ b/website/docs/cordova/ads/banner.md
@@ -15,7 +15,6 @@ document.addEventListener('deviceready', async () => {
     adUnitId: 'ca-app-pub-xxx/yyy',
   })
 
-  await banner.load()
   await banner.show()
 
   await banner.hide()


### PR DESCRIPTION
 First time doing a pull request on another’s repo so please let me know if there’s a different process to follow. Was having some trouble today getting a banner ad to show, and when I looked at the docs I saw the `load` method wasn’t there. The steps for creating a banner ad still has it so this change just removes that line which worked for me when testing.
