### PR TITLE
Add close-listener

### DIFF
--- a/website/docs/cordova/ads/banner.md
+++ b/website/docs/cordova/ads/banner.md
@@ -51,3 +51,7 @@ An ad request has been failed.
 ### `admob.banner.impression`
 
 An ad has been displayed.
+
+### `admob.banner.close`
+
+An ad has been clicked (return from browser).


### PR DESCRIPTION
The `admob.banner.close` listener / event is still working for me.

When I bind the event to the ad, it "fires" when you click on the ad, see the ad-campaign in the browser and return to the app itself.

---

Also, in previous versions `admob.banner.click` was active, but it isn't anymore?

Of course, you can only `close` and ad once `clicked`, so the `close event`  is linked to a click.

But it would be nice to have a `click event` as well, because one can click and never return to the app (so the `return statement` / `close event` is never fired in that flow).