### PR TITLE
Add a little branding to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # [AdMob Plus](https://admob-plus.github.io)
 
-AdMob Plus is the successor of [cordova-plugin-admob-free](https://github.com/ratson/cordova-plugin-admob-free), which provides a cleaner API and build with modern tools.
+![AdMob Plus logotype](https://admob-plus.github.io/img/logo.png "AdMob Plus logotype")
+
+[**AdMob Plus**](https://admob-plus.github.io) is the successor of [cordova-plugin-admob-free](https://github.com/ratson/cordova-plugin-admob-free), provides a cleaner API and is build with modern tools.
 
 ## Features
 


### PR DESCRIPTION
**Maybe it's a (good) idea to add a little branding to the readme, since this is the first thing new users do see when exploring the repository.**

The logotype is too big in this example, but you can downscale it.

Another useful adjustment can be that the very first link in the text now links to the real site and not the deprecated one... (this could be confusing).

And in the initial text, it looked like "cordova-plugin-admob-free" offered a cleaner API and was build with modern tools (which was  not the case).

---

Just some ideas to make a more warm and clear "welcome" for new users :-)