### PR TITLE
Styling of the logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <h1 align="center">
   <p align="center">AdMob Plus</p>
   <a href="https://admob-plus.github.io">
-    <img alt="AdMob Plus" src="https://admob-plus.github.io/img/logo.png">
+    <img alt="AdMob Plus" src="https://admob-plus.github.io/img/logo.png" style="max-width: 320px !important;">
   </a>
 </h1>
 
-[**AdMob Plus**](https://admob-plus.github.io) is the successor of [cordova-plugin-admob-free](https://github.com/ratson/cordova-plugin-admob-free), provides a clean API and is build with modern tools.
+[**AdMob Plus**](https://admob-plus.github.io) is the successor of [cordova-plugin-admob-free](https://github.com/ratson/cordova-plugin-admob-free) provides a clean API and is build with modern tools.
 
 ## Other features
 


### PR DESCRIPTION
- I've set a `maximum width` of `320px` for the logo in **README.md**
- Without doing so, the image inherits the `100% width`, set in a .scss file that's also active on this .git repo
- Also, the `max-width` makes the image more `responsive` on smaller (mobile) screens