### PR TITLE
feat(cordova/android): New admob.banner.size event to get banner width/height

### DIFF
--- a/packages/cordova/src/android/Generated.java
+++ b/packages/cordova/src/android/Generated.java
@@ -31,6 +31,7 @@ public final class Generated {
         public static final String BANNER_LOAD = "admob.banner.load";
         public static final String BANNER_LOAD_FAIL = "admob.banner.loadfail";
         public static final String BANNER_OPEN = "admob.banner.open";
+        public static final String BANNER_SIZE = "admob.banner.size";
         public static final String BANNER_SIZE_CHANGE = "admob.banner.sizechange";
         public static final String INTERSTITIAL_DISMISS = "admob.interstitial.dismiss";
         public static final String INTERSTITIAL_IMPRESSION = "admob.interstitial.impression";

--- a/packages/cordova/src/ios/AMBGenerated.swift
+++ b/packages/cordova/src/ios/AMBGenerated.swift
@@ -11,6 +11,7 @@ struct AMBEvents {
     static let bannerLoad = "admob.banner.load"
     static let bannerLoadFail = "admob.banner.loadfail"
     static let bannerOpen = "admob.banner.open"
+    static let bannerSize = "admob.banner.size"
     static let bannerSizeChange = "admob.banner.sizechange"
     static let interstitialDismiss = "admob.interstitial.dismiss"
     static let interstitialImpression = "admob.interstitial.impression"

--- a/website/docs/cordova/ads/banner.md
+++ b/website/docs/cordova/ads/banner.md
@@ -89,3 +89,22 @@ An ad request has been failed.
 ### `admob.banner.impression`
 
 An ad has been displayed.
+
+### `admob.banner.size`
+
+Event that return the ad size.
+
+```js
+document.addEventListener('admob.banner.size', async (event) => {
+  /* event:
+  {
+    adId: int,
+    size: {
+      width: int,
+      height: int,
+      widthInPixels: int,
+      heightInPixels: int
+    }
+  }*/
+})
+```


### PR DESCRIPTION
New event `admob.banner.size` to get the banner size, to be used with `offset: 0` or for other reasons.

I plan to add this event on iOS as well, but currently I don't have the latest version of Xcode, so I can't compile it.