### PR TITLE
feat(cordova/ios): admob.banner.size event also fires on iOS

### DIFF
--- a/packages/cordova/src/ios/AMBBanner.swift
+++ b/packages/cordova/src/ios/AMBBanner.swift
@@ -1,4 +1,5 @@
 import GoogleMobileAds
+import UIKit
 
 class AMBBanner: AMBAdBase, GADBannerViewDelegate, GADAdSizeDelegate {
     static let stackView = UIStackView(frame: rootView.frame)
@@ -205,6 +206,14 @@ class AMBBanner: AMBAdBase, GADBannerViewDelegate, GADAdSizeDelegate {
 
     func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
         self.emit(AMBEvents.bannerLoad)
+        self.emit(AMBEvents.bannerSize, [
+            "size": [
+                "width": bannerView.frame.size.width,
+                "height": bannerView.frame.size.height,
+                "widthInPixels": round(bannerView.frame.size.width * UIScreen.main.scale),
+                "heightInPixels": round(bannerView.frame.size.height * UIScreen.main.scale)
+            ]
+        ])
     }
 
     func bannerView(_ bannerView: GADBannerView,

--- a/website/docs/cordova/ads/banner.md
+++ b/website/docs/cordova/ads/banner.md
@@ -90,10 +90,9 @@ An ad request has been failed.
 
 An ad has been displayed.
 
-<!--
 ### `admob.banner.size`
 
-Event that return the ad size.
+Event that return the ad size, this event is also fired when the ad is resized, for example by rotating the device.
 
 ```js
 document.addEventListener('admob.banner.size', async (event) => {
@@ -109,4 +108,3 @@ document.addEventListener('admob.banner.size', async (event) => {
   }*/
 })
 ```
--->

--- a/website/docs/cordova/consent/request.md
+++ b/website/docs/cordova/consent/request.md
@@ -15,7 +15,14 @@ cordova plugin add cordova-plugin-consent
 ```js
 document.addEventListener('deviceready', async () => {
   if (cordova.platformId === 'ios') {
-    await admob.requestTrackingAuthorization()
+    const trackingAuthorizationStatus = await admob.requestTrackingAuthorization()
+    /*
+      trackingAuthorizationStatus:
+      0 = notDetermined
+      1 = restricted
+      2 = denied
+      3 = authorized
+    */
   }
 
   const consentStatus = await consent.getConsentStatus()
@@ -44,6 +51,7 @@ new admob.BannerAd({
 
 ## References
 
+- [TrackingAuthorizationStatus](../api/enums/trackingauthorizationstatus.md)
 - [UMP SDK for Android](https://developers.google.com/admob/ump/android/quick-start)
 - [UMP SDK for iOS](https://developers.google.com/admob/ump/ios/quick-start)
 - [AppTrackingTransparency Framework](https://developer.apple.com/documentation/apptrackingtransparency)


### PR DESCRIPTION
I have added `admob.banner.size` event on iOS, I am tested it on Xcode emulator (iPhone 12 and iOS 14.4) and it works correctly.

I have also updated the documentation for `requestTrackingAuthorization` to better understand how it works and the values it can return.