### PR TITLE
Hide banner instead of load

### DIFF
--- a/packages/capacitor/src/index.ts
+++ b/packages/capacitor/src/index.ts
@@ -101,7 +101,7 @@ class BannerAd extends MobileAd {
   }
 
   hide() {
-    return super.load()
+    return super.hide()
   }
 }
 


### PR DESCRIPTION
Hi @ratson thank you for this awesome plugin.

I noticed that in the newest version of `@admob-plus/capacitor@1.16.0` the banner stopped hiding correctly because the `hide` implementation of `BannerAd` was using `super.load()`.

This PR is trying to address it. The `hide` method in `BannerAd` can be probably just removed since it only calls `super.hide()` right now.