### PR TITLE
fix Rewarded Ads Server-side Verification

### DIFF
--- a/packages/capacitor/android/src/main/java/admob/plus/capacitor/ads/Rewarded.java
+++ b/packages/capacitor/android/src/main/java/admob/plus/capacitor/ads/Rewarded.java
@@ -16,9 +16,12 @@ import admob.plus.core.GenericAd;
 
 public class Rewarded extends AdBase implements GenericAd {
     private RewardedAd mAd = null;
+    private ServerSideVerificationOptions ssv = null;
 
     public Rewarded(ExecuteContext ctx) {
         super(ctx);
+
+        this.ssv = ctx.optServerSideVerificationOptions();
     }
 
     @Override
@@ -42,7 +45,6 @@ public class Rewarded extends AdBase implements GenericAd {
             @Override
             public void onAdLoaded(@NonNull RewardedAd rewardedAd) {
                 mAd = rewardedAd;
-                ServerSideVerificationOptions ssv = ctx.optServerSideVerificationOptions();
                 if (ssv != null) {
                     mAd.setServerSideVerificationOptions(ssv);
                 }

--- a/packages/capacitor/android/src/main/java/admob/plus/capacitor/ads/RewardedInterstitial.java
+++ b/packages/capacitor/android/src/main/java/admob/plus/capacitor/ads/RewardedInterstitial.java
@@ -16,9 +16,12 @@ import admob.plus.core.GenericAd;
 
 public class RewardedInterstitial extends AdBase implements GenericAd {
     private RewardedInterstitialAd mAd = null;
+    private ServerSideVerificationOptions ssv = null;
 
     public RewardedInterstitial(ExecuteContext ctx) {
         super(ctx);
+
+        this.ssv = ctx.optServerSideVerificationOptions();
     }
 
     @Override
@@ -42,7 +45,6 @@ public class RewardedInterstitial extends AdBase implements GenericAd {
             @Override
             public void onAdLoaded(@NonNull RewardedInterstitialAd rewardedAd) {
                 mAd = rewardedAd;
-                ServerSideVerificationOptions ssv = ctx.optServerSideVerificationOptions();
                 if (ssv != null) {
                     mAd.setServerSideVerificationOptions(ssv);
                 }

--- a/packages/cordova/src/android/cordova/ads/Rewarded.java
+++ b/packages/cordova/src/android/cordova/ads/Rewarded.java
@@ -16,9 +16,12 @@ import admob.plus.core.Context;
 
 public class Rewarded extends AdBase {
     private RewardedAd mAd = null;
+    private ServerSideVerificationOptions ssv = null;
 
     public Rewarded(ExecuteContext ctx) {
         super(ctx);
+
+        this.ssv = ctx.optServerSideVerificationOptions();
     }
 
     @Override
@@ -44,7 +47,6 @@ public class Rewarded extends AdBase {
             @Override
             public void onAdLoaded(@NonNull RewardedAd rewardedAd) {
                 mAd = rewardedAd;
-                ServerSideVerificationOptions ssv = ctx.optServerSideVerificationOptions();
                 if (ssv != null) {
                     mAd.setServerSideVerificationOptions(ssv);
                 }

--- a/packages/cordova/src/android/cordova/ads/RewardedInterstitial.java
+++ b/packages/cordova/src/android/cordova/ads/RewardedInterstitial.java
@@ -16,9 +16,12 @@ import admob.plus.core.Context;
 
 public class RewardedInterstitial extends AdBase {
     private RewardedInterstitialAd mAd = null;
+    private ServerSideVerificationOptions ssv = null;
 
     public RewardedInterstitial(ExecuteContext ctx) {
         super(ctx);
+
+        this.ssv = ctx.optServerSideVerificationOptions();
     }
 
     @Override
@@ -44,7 +47,6 @@ public class RewardedInterstitial extends AdBase {
             @Override
             public void onAdLoaded(@NonNull RewardedInterstitialAd rewardedAd) {
                 mAd = rewardedAd;
-                ServerSideVerificationOptions ssv = ctx.optServerSideVerificationOptions();
                 if (ssv != null) {
                     mAd.setServerSideVerificationOptions(ssv);
                 }

--- a/packages/react-native/android/src/main/java/admob/plus/rn/ads/Rewarded.java
+++ b/packages/react-native/android/src/main/java/admob/plus/rn/ads/Rewarded.java
@@ -16,9 +16,12 @@ import admob.plus.rn.Generated.Events;
 
 public class Rewarded extends AdBase implements GenericAd {
     private RewardedAd mAd = null;
+    private ServerSideVerificationOptions ssv = null;
 
     public Rewarded(ExecuteContext ctx) {
         super(ctx);
+
+        this.ssv = ctx.optServerSideVerificationOptions();
     }
 
     @Override
@@ -42,7 +45,6 @@ public class Rewarded extends AdBase implements GenericAd {
             @Override
             public void onAdLoaded(@NonNull RewardedAd rewardedAd) {
                 mAd = rewardedAd;
-                ServerSideVerificationOptions ssv = ctx.optServerSideVerificationOptions();
                 if (ssv != null) {
                     mAd.setServerSideVerificationOptions(ssv);
                 }

--- a/packages/react-native/android/src/main/java/admob/plus/rn/ads/RewardedInterstitial.java
+++ b/packages/react-native/android/src/main/java/admob/plus/rn/ads/RewardedInterstitial.java
@@ -16,9 +16,12 @@ import admob.plus.rn.Generated.Events;
 
 public class RewardedInterstitial extends AdBase implements GenericAd {
     private RewardedInterstitialAd mAd = null;
+    private ServerSideVerificationOptions ssv = null;
 
     public RewardedInterstitial(ExecuteContext ctx) {
         super(ctx);
+
+        this.ssv = ctx.optServerSideVerificationOptions();
     }
 
     @Override
@@ -42,7 +45,6 @@ public class RewardedInterstitial extends AdBase implements GenericAd {
             @Override
             public void onAdLoaded(@NonNull RewardedInterstitialAd rewardedAd) {
                 mAd = rewardedAd;
-                ServerSideVerificationOptions ssv = ctx.optServerSideVerificationOptions();
                 if (ssv != null) {
                     mAd.setServerSideVerificationOptions(ssv);
                 }


### PR DESCRIPTION
Before AdMob didn't send "customData" and "userId" to callback URL, because ServerSideVerificationOptions always was null.
