### PR TITLE
IOS - Upgrade Admob SDK to 9.12.0

### DIFF
--- a/packages/cordova/CHANGELOG.md
+++ b/packages/cordova/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.29.0](https://github.com/admob-plus/admob-plus/compare/admob-plus-cordova@1.27.0...admob-plus-cordova@1.28.0) (2022-08-14)
+
+
+### Features
+
+* **Admob SDK:** upgraded to 9.12.0
+
+
+
 # [1.28.0](https://github.com/admob-plus/admob-plus/compare/admob-plus-cordova@1.27.0...admob-plus-cordova@1.28.0) (2022-08-14)
 
 

--- a/packages/cordova/package.json
+++ b/packages/cordova/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admob-plus-cordova",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Trustable Google AdMob Cordova Plugin",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/packages/cordova/plugin.xml
+++ b/packages/cordova/plugin.xml
@@ -262,7 +262,7 @@
                 <source url="https://cdn.cocoapods.org/" />
             </config>
             <pods use-frameworks="true">
-                <pod name="Google-Mobile-Ads-SDK" spec="~> 8.13.0" />
+                <pod name="Google-Mobile-Ads-SDK" spec="~> 9.12.0" />
             </pods>
         </podspec>
     </platform>

--- a/packages/cordova/plugin.xml
+++ b/packages/cordova/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="admob-plus-cordova" version="1.28.0"
+<plugin id="admob-plus-cordova" version="1.29.0"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <name>admob-plus-cordova</name>

--- a/packages/cordova/plugin.xml
+++ b/packages/cordova/plugin.xml
@@ -262,7 +262,7 @@
                 <source url="https://cdn.cocoapods.org/" />
             </config>
             <pods use-frameworks="true">
-                <pod name="Google-Mobile-Ads-SDK" spec="~> 9.12.0" />
+                <pod name="Google-Mobile-Ads-SDK" spec="~> 10.1.0" />
             </pods>
         </podspec>
     </platform>

--- a/packages/cordova/src/ios/AMBAppOpenAd.swift
+++ b/packages/cordova/src/ios/AMBAppOpenAd.swift
@@ -71,7 +71,7 @@ class AMBAppOpenAd: AMBAdBase, GADFullScreenContentDelegate {
         self.emit(AMBEvents.adShowFail, error)
     }
 
-    func adDidPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         self.emit(AMBEvents.adShow)
     }
 

--- a/packages/cordova/src/ios/AMBInterstitial.swift
+++ b/packages/cordova/src/ios/AMBInterstitial.swift
@@ -51,7 +51,7 @@ class AMBInterstitial: AMBAdBase, GADFullScreenContentDelegate {
         self.emit(AMBEvents.interstitialShowFail, error)
     }
 
-    func adDidPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         self.emit(AMBEvents.adShow)
         self.emit(AMBEvents.interstitialShow)
     }

--- a/packages/cordova/src/ios/AMBRewarded.swift
+++ b/packages/cordova/src/ios/AMBRewarded.swift
@@ -54,7 +54,7 @@ class AMBRewarded: AMBAdBase, GADFullScreenContentDelegate {
         self.emit(AMBEvents.rewardedShowFail, error)
     }
 
-    func adDidPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         self.emit(AMBEvents.adShow)
         self.emit(AMBEvents.rewardedShow)
     }

--- a/packages/cordova/src/ios/AMBRewardedInterstitial.swift
+++ b/packages/cordova/src/ios/AMBRewardedInterstitial.swift
@@ -54,7 +54,7 @@ class AMBRewardedInterstitial: AMBAdBase, GADFullScreenContentDelegate {
         self.emit(AMBEvents.rewardedInterstitialShowFail, error)
     }
 
-    func adDidPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         self.emit(AMBEvents.adShow)
         self.emit(AMBEvents.rewardedInterstitialShow)
     }


### PR DESCRIPTION
IOS - Upgrade Admob SDK to 9.12.0:
* Admob SDK version
* upgraded relevant files with methods name that changed