### PR TITLE
fix(cordova): some fixes for the WebView API for Ads

### DIFF
--- a/packages/cordova/plugin.xml
+++ b/packages/cordova/plugin.xml
@@ -23,6 +23,7 @@
             <meta-data android:name="com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT" android:value="true"/>
             <meta-data android:name="com.google.android.gms.ads.flag.OPTIMIZE_INITIALIZATION" android:value="true" />
             <meta-data android:name="com.google.android.gms.ads.flag.OPTIMIZE_AD_LOADING" android:value="true" />
+            <meta-data android:name="com.google.android.gms.ads.flag.INTEGRATION_MANAGER" android:value="webview" />
         </config-file>
 
         <config-file target="res/xml/config.xml" parent="/*">

--- a/packages/cordova/plugin.xml
+++ b/packages/cordova/plugin.xml
@@ -84,6 +84,10 @@
             <string>$USAGE</string>
         </config-file>
 
+        <config-file target="*-Info.plist" parent="GADIntegrationManager">
+            <string>webview</string>
+        </config-file>
+
         <config-file target="*-Info.plist" parent="SKAdNetworkItems">
             <array>
                 <dict>

--- a/packages/cordova/src/android/cordova/AdMob.kt
+++ b/packages/cordova/src/android/cordova/AdMob.kt
@@ -89,7 +89,7 @@ class AdMob : CordovaPlugin() {
             // Adding the MIME type to http: URLs causes them to not be handled by the downloader.
             val uri = Uri.parse(url)
             intent.setData(uri)
-            if (uri.scheme in setOf("http", "https")) {
+            if (uri.scheme in setOf("http", "https") && url != webView.getUrl()) {
                 cordova.activity.startActivity(intent)
                 Log.d(TAG, "Open Iframe URL to browser $url")
                 //webView.sendJavascript("cordova.InAppBrowser.open('" + url + "', '_system');");

--- a/packages/cordova/src/ios/AMBPlugin.swift
+++ b/packages/cordova/src/ios/AMBPlugin.swift
@@ -15,6 +15,9 @@ class AMBPlugin: CDVPlugin, WKNavigationDelegate {
         readyCallbackId = nil
     }
 
+    var navigationDelegate: WKNavigationDelegate?
+    var overrideUrlLoading: Bool = true
+
     override func pluginInitialize() {
         super.pluginInitialize()
 
@@ -27,24 +30,56 @@ class AMBPlugin: CDVPlugin, WKNavigationDelegate {
             // webView.reload()
         }
 
+        if let x = self.commandDelegate.settings["AdMobPlusOverrideUrlLoading".lowercased()] as? String,
+           x == "true" {
+            let webView = self.webViewEngine.engineWebView as! WKWebView
+            self.navigationDelegate = webView.navigationDelegate
+            webView.navigationDelegate = self
+        }
+
         if let x = self.commandDelegate.settings["disableSDKCrashReporting".lowercased()] as? String,
            x == "true" {
             GADMobileAds.sharedInstance().disableSDKCrashReporting()
         }
     }
 
-    var overrideUrlLoading: Bool = true
+    /*
+        Correct way of OverrideLoadWithRequest, but cannot currently be used due to a limitation, use the webView.navigationDelegate for now
+        See also: https://github.com/apache/cordova-ios/pull/1333
+    */
+    /*
+    @objc func shouldOverrideLoadWithRequest(_ request: URLRequest, navigationAction: WKNavigationAction) -> Bool {
 
-    @objc func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        if navigationAction.sourceFrame == nil, overrideUrlLoading {
+        var allowNavigationsPass = true
+
+        if overrideUrlLoading {
             if let url = navigationAction.request.url, url.scheme == "http" || url.scheme == "https" {
-                UIApplication.shared.open(url)
-                decisionHandler(.cancel)
-                return
+
+                if navigationAction.sourceFrame == nil {
+                    allowNavigationsPass = false
+                }
+
+                switch navigationAction.navigationType {
+                    case .linkActivated:
+                        allowNavigationsPass = false
+                    case .other:
+                        let range = url.absoluteString.range(of: "utm_content")
+                        if range != nil {
+                            allowNavigationsPass = false
+                        }
+                    default:
+                        break
+                }
+
+                if !allowNavigationsPass {
+                    UIApplication.shared.open(url)
+                }
             }
         }
-        decisionHandler(.allow)
+
+        return allowNavigationsPass
     }
+    */
 
     @objc func ready(_ command: CDVInvokedUrlCommand) {
         readyCallbackId = command.callbackId
@@ -100,12 +135,6 @@ class AMBPlugin: CDVPlugin, WKNavigationDelegate {
         GADMobileAds.sharedInstance().start(completionHandler: { _ in
             ctx.resolve(["version": GADMobileAds.sharedInstance().sdkVersion])
         })
-
-        if let x = self.commandDelegate.settings["AdMobPlusWebViewAd".lowercased()] as? String,
-           x == "true" {
-            let webView = self.webViewEngine.engineWebView as! WKWebView
-            webView.navigationDelegate = self
-        }
     }
 
     @objc func setAppMuted(_ command: CDVInvokedUrlCommand) {
@@ -233,4 +262,87 @@ class AMBPlugin: CDVPlugin, WKNavigationDelegate {
         result?.setKeepCallbackAs(true)
         self.commandDelegate.send(result, callbackId: readyCallbackId)
     }
+
+    // WKNavigationDelegate - this can be removed and replaced with shouldOverrideLoadWithRequest when it works without the limitation
+
+    @objc func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+
+        var allowNavigationsPass = true
+
+        if overrideUrlLoading {
+            if let url = navigationAction.request.url, url.scheme == "http" || url.scheme == "https" {
+
+                if navigationAction.sourceFrame == nil {
+                    allowNavigationsPass = false
+                }
+
+                switch navigationAction.navigationType {
+                    case .linkActivated:
+                        allowNavigationsPass = false
+                    case .other:
+                        let range = url.absoluteString.range(of: "utm_content")
+                        if range != nil {
+                            allowNavigationsPass = false
+                        }
+                    default:
+                        break
+                }
+
+                if !allowNavigationsPass {
+                    UIApplication.shared.open(url)
+                    decisionHandler(.cancel)
+                    return
+                }
+            }
+        }
+
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webView(_:decidePolicyFor:decisionHandler:))) {
+            navigationDelegate.webView?(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler)
+        } else {
+            decisionHandler(.allow)
+        }
+    }
+
+    @objc func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webView(_:didCommit:))) {
+            navigationDelegate.webView?(webView, didCommit: navigation)
+        }
+    }
+
+    @objc func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webView(_:didFinish:))) {
+            navigationDelegate.webView?(webView, didFinish: navigation)
+        }
+    }
+
+    @objc func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webView(_:didFail:withError:))) {
+            navigationDelegate.webView?(webView, didFail: navigation, withError: error)
+        }
+    }
+
+    @objc func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webViewWebContentProcessDidTerminate(_:))) {
+            navigationDelegate.webViewWebContentProcessDidTerminate?(webView)
+        }
+    }
+
+    @objc func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webView(_:didStartProvisionalNavigation:))) {
+            navigationDelegate.webView?(webView, didStartProvisionalNavigation: navigation)
+        }
+    }
+
+    @objc func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webView(_:didFailProvisionalNavigation:withError:))) {
+            navigationDelegate.webView?(webView, didFailProvisionalNavigation: navigation, withError: error)
+        }
+    }
+
+    @objc func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+        if let navigationDelegate = self.navigationDelegate, navigationDelegate.responds(to: #selector(webView(_:didReceiveServerRedirectForProvisionalNavigation:))) {
+            navigationDelegate.webView?(webView, didReceiveServerRedirectForProvisionalNavigation: navigation)
+        }
+    }
+
 }

--- a/website/docs/cordova/ads/webview.md
+++ b/website/docs/cordova/ads/webview.md
@@ -36,6 +36,7 @@ It is also necessary to add your AdSense domain as `Hostname` of the CordovaWebV
 <preference name="Scheme" value="https" />
 <preference name="Hostname" value="example.com" />
 <preference name="AdMobPlusWebViewAd" value="true" />
+<preference name="AdMobPlusOverrideUrlLoading" value="true" />
 ```
 
 If ads are not displayed correctly (Probably on iOS), you may also need to add the following config to your `config.xml`
@@ -102,9 +103,8 @@ Remove this from `config.xml` or change to `false` (If you also use the WebView 
 ```xml
 <preference name="AdMobPlusWebViewAd" value="true" />
 ```
-And add this preference and hook:
+And add this hook:
 ```xml
-<preference name="AdMobPlusOverrideUrlLoading" value="true" />
 <hook type="before_build" src="update_main_activity.sh" />
 ```
 


### PR DESCRIPTION
Hi @ratson, I have made some fixes in the WebView API for Ads implementation.

76169910d2b98dbb1af225abc497a5cab40ec03b fix(cordova/android): onOverrideUrlLoading fires when the WebView is reloaded, fix https://github.com/EYALIN/community-admob-plus/issues/6

4d6f56c3aa1564b9494ac9377f332450e156f700 fix(cordova/ios):  add GADIntegrationManager preference [Integrate the WebView API for Ads in IOS: Before you begin](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/webview#before_you_begin)

8cea3e6bd4e1a16175bcc4c06426be78c76be8c4 docs(cordova): update webview.md

c8f298abc20416e76b6b8bb06a6a49acacd7db7a fix(cordova/ios): correct way to use the navigationDelegate and final fix for white screen, in the future, `shouldOverrideLoadWithRequest` should be used instead of `webView.navigationDelegate`, but currently has a limitation https://github.com/apache/cordova-ios/pull/1333

11225b3a78cb7e14081d7a0788931af0713ad471 fix(cordova/android): add INTEGRATION_MANAGER preference [Integrate the WebView API for Ads in Android: Prerequisites](https://developers.google.com/admob/android/webview#prerequisites)